### PR TITLE
add rectangular bezier patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,167 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+.vscode/
+logs/
+output/
+results/

--- a/classification.py
+++ b/classification.py
@@ -31,6 +31,10 @@ parser.add_argument(
     "--gpu", type=int,default=0, help="choose gpu"
 )
 
+parser.add_argument(
+    "--num_control_pts", type=int, default=28, help="Number of control points for bezier patches"
+)
+
 parser.add_argument("--dataset_dir", type=str, help="Directory to datasets")
 parser.add_argument("--batch_size", type=int, default=64, help="Batch size")
 parser.add_argument(
@@ -109,7 +113,7 @@ results/{experiment_name}/{month_day}/{hour_min_second}/best.ckpt
     if args.checkpoint is not None:
         model=ClassificationModel.load_from_checkpoint(args.checkpoint)
     else:
-        model_hparams = {'method': args.method,'num_classes':args.num_classes,"masking_rate":None}
+        model_hparams = {'method': args.method,'num_classes':args.num_classes,"masking_rate":None,"num_control_pts":args.num_control_pts}
         if model_hparams is not None:
             model = ClassificationModel(**model_hparams)
         else:

--- a/models/brt.py
+++ b/models/brt.py
@@ -127,13 +127,13 @@ class WireNet(nn.Module):
 
 
 class BRT(nn.Module):
-    def __init__(self, dmodel=256, hidden_dim=2048, n_layers=4, n_heads=16, dropout=0.01, max_face_length=90):
+    def __init__(self, dmodel=256, hidden_dim=2048, n_layers=4, n_heads=16, dropout=0.01, max_face_length=90,num_control_pts=28):
         super(BRT, self).__init__()
         self.edge_layer = EdgeEncoder(
             input_dim=4 * 11, srf_emb_dim=dmodel, dropout=dropout, hidden_dim=hidden_dim, n_layers=2, n_heads=4
         )
         self.face_layer = FaceEncoder(
-            input_dim=28 * 4 + 1 + 7, srf_emb_dim=dmodel, dropout=dropout, hidden_dim=hidden_dim, n_layers=2, n_heads=4
+            input_dim=num_control_pts * 4 + 1 + 7, srf_emb_dim=dmodel, dropout=dropout, hidden_dim=hidden_dim, n_layers=2, n_heads=4
         )
 
         self.topo_layer = TopoEncoder(vertex_dim=3, edge_dim=dmodel, h_dim=2 * dmodel, dropout=dropout)

--- a/models/brt_classfication.py
+++ b/models/brt_classfication.py
@@ -8,10 +8,10 @@ import torchmetrics
 
 
 class BRTClassification(nn.Module):
-    def __init__(self, num_classes, d_model=64, masking_rate=None, max_face_length=100):
+    def __init__(self, num_classes, d_model=64, masking_rate=None, max_face_length=100,num_control_pts=28):
         super().__init__()
         self.model = BRT(
-            dmodel=d_model, hidden_dim=512, n_layers=2, n_heads=4, max_face_length=max_face_length, dropout=0.25
+            dmodel=d_model, hidden_dim=512, n_layers=2, n_heads=4, max_face_length=max_face_length, dropout=0.25,num_control_pts=num_control_pts
         )
         self.head = _NonLinearClassifier(d_model, num_classes)
         self.masking_rate = masking_rate
@@ -36,14 +36,14 @@ class ClassificationPL(pl.LightningModule):
     PyTorch Lightning module to train/test the classifier.
     """
 
-    def __init__(self, num_classes=15, method="brt", masking_rate=None):
+    def __init__(self, num_classes=15, method="brt", masking_rate=None,num_control_pts=28):
         """
         Args:
             num_classes (int): Number of per-solid classes in the dataset
         """
         super().__init__()
         self.save_hyperparameters()
-        self.model = BRTClassification(num_classes=num_classes, masking_rate=masking_rate)
+        self.model = BRTClassification(num_classes=num_classes, masking_rate=masking_rate,num_control_pts=num_control_pts)
         self.masking_rate = masking_rate
         self.train_acc = torchmetrics.Accuracy(
             task="multiclass",

--- a/models/brt_segmentation.py
+++ b/models/brt_segmentation.py
@@ -9,10 +9,10 @@ import torchmetrics
 
 
 class BRTSegmentation(nn.Module):
-    def __init__(self, num_classes, d_model=64, max_face_length=100, masking_rate=None):
+    def __init__(self, num_classes, d_model=64, max_face_length=100, masking_rate=None,num_control_pts=28):
         super().__init__()
         self.model = BRT(
-            dmodel=d_model, hidden_dim=8 * d_model, n_layers=2, n_heads=8, dropout=0.25, max_face_length=max_face_length
+            dmodel=d_model, hidden_dim=8 * d_model, n_layers=2, n_heads=8, dropout=0.25, max_face_length=max_face_length,num_control_pts=num_control_pts
         )
         self.head = _NonLinearClassifier(d_model, num_classes)
         self.masking_rate = masking_rate
@@ -36,14 +36,14 @@ class SegmentationPL(pl.LightningModule):
     PyTorch Lightning module to train/test the classifier.
     """
 
-    def __init__(self, num_classes=25, method="brt", masking_rate=None):
+    def __init__(self, num_classes=25, method="brt", masking_rate=None,num_control_pts=28):
         """
         Args:
             num_classes (int): Number of per-solid classes in the dataset
         """
         super().__init__()
         self.save_hyperparameters()
-        self.model = BRTSegmentation(num_classes=num_classes, masking_rate=masking_rate)
+        self.model = BRTSegmentation(num_classes=num_classes, masking_rate=masking_rate,num_control_pts=num_control_pts)
         self.masking_rate = masking_rate
         self.train_acc = torchmetrics.Accuracy(
             task="multiclass",

--- a/process/gen_tmcad_rectangles.py
+++ b/process/gen_tmcad_rectangles.py
@@ -1,0 +1,20 @@
+import logging
+from solid_to_triangles2 import process_main
+import argparse
+import os.path
+
+if not os.path.exists("logs"):
+    os.makedirs("logs", exist_ok=True)
+
+logging.basicConfig(
+    filename="logs/solid_to_triangles",
+    filemode="w",
+    format=" %(asctime)s :: %(levelname)-8s :: %(message)s",
+    level=logging.INFO,
+)
+
+paser = argparse.ArgumentParser("Convert each face of solid models into triangular beziers")
+paser.add_argument("data_path", type=str)
+paser.add_argument("output_path", type=str)
+args = paser.parse_args()
+process_main(args.data_path, args.output_path, method=18, dataset="tmcad", target="rectangles", process_num=30)

--- a/process/utils/bezier2.py
+++ b/process/utils/bezier2.py
@@ -1,12 +1,12 @@
 import numpy as np
 import logging
-from utils.triangle import Triangle, BoundaryEdge, isClose, Rectangular2TriangularBezier
+from OCC.Core.ShapeAnalysis import ShapeAnalysis_Surface
+from utils.triangle import Triangle,BoundaryEdge,isClose,Rectangular2TriangularBezier
 from occwl.face import Face
 from occwl.geometry import geom_utils
 from OCC.Core.TopLoc import TopLoc_Location
 from OCC.Core.BRep import BRep_Tool
 from OCC.Core.GeomLProp import GeomLProp_SLProps
-
 
 def pointOnFace(face, uv):
     """
@@ -14,17 +14,16 @@ def pointOnFace(face, uv):
 
     Args:
         uv (np.ndarray or tuple): Surface parameter
-
+    
     Returns:
         np.ndarray: 3D Point
     """
-    self = face
+    self=face
     loc = TopLoc_Location()
     surf = BRep_Tool().Surface(self.topods_shape(), loc)
     pt = surf.Value(uv[0], uv[1])
     pt = pt.Transformed(loc.Transformation())
     return geom_utils.gp_to_numpy(pt)
-
 
 def getCenterAndScale(points):
     x = points[:, 0]
@@ -34,150 +33,211 @@ def getCenterAndScale(points):
     bbox = np.array(bbox)
 
     diag = bbox[1] - bbox[0]
-    scale = [(2.0 / d) if d > 1e-6 else 1 for d in diag]
-    scale = np.array(scale)
+    scale = [(2.0 / d) if d>1e-6 else 1 for d in diag]
+    scale= np.array(scale)
     center = 0.5 * (bbox[0] + bbox[1])
 
-    return center, scale
+    return center,scale
 
+def bernstein_polynomial_all(degree,u,v):
+    w=1-u-v
+    init_array=np.array([[w,0],[u,v]],dtype=np.float32)
+    if degree>1:
+        for i in range(degree-1):
+            new_array=np.zeros(((i+3),(i+3)),dtype=np.float32)
+            for j in range(i+2):
+                for k in range(j+1):
+                    new_array[j,k]+=init_array[j,k]*w
+                    new_array[j+1,k]+=init_array[j,k]*u
+                    new_array[j+1,k+1]+=init_array[j,k]*v
+            init_array=new_array
 
-def bernstein_polynomial_all(degree, u, v):
-    w = 1 - u - v
-    init_array = np.array([[w, 0], [u, v]], dtype=np.float32)
-    if degree > 1:
-        for i in range(degree - 1):
-            new_array = np.zeros(((i + 3), (i + 3)), dtype=np.float32)
-            for j in range(i + 2):
-                for k in range(j + 1):
-                    new_array[j, k] += init_array[j, k] * w
-                    new_array[j + 1, k] += init_array[j, k] * u
-                    new_array[j + 1, k + 1] += init_array[j, k] * v
-            init_array = new_array
-
-    nodes = []
-    for i in range(degree + 1):
-        for j in range(degree + 1 - i):
-            nodes.append(init_array[degree - i, j])
+    nodes=[]
+    for i in range(degree+1):
+        for j in range(degree+1-i):
+            nodes.append(init_array[degree-i,j])
     return np.array(nodes)
-
-
-def bernstein_polynomial_all_multi(degree, u, v):
-    nodes = [bernstein_polynomial_all(degree, u[i], v[i]) for i in range(len(u))]
-    nodes = np.stack(nodes)
+def bernstein_polynomial_all_multi(degree,u,v):
+    nodes=[bernstein_polynomial_all(degree,u[i],v[i]) for i in range(len(u))]
+    nodes=np.stack(nodes)
     return nodes
-
-
-def fit_bezier_surface2(points, uvs, initial_control_points=None, bn_cache=[]):
+def fit_bezier_surface2(points,uvs, initial_control_points=None,bn_cache=[]):
     """Fit a triangular Bézier surface to the given points."""
-    if bn_cache is None or len(bn_cache) == 0:
-        bn = bernstein_polynomial_all_multi(6, uvs[:, 0], uvs[:, 1])
+    if bn_cache is None or len(bn_cache)==0:
+        bn=bernstein_polynomial_all_multi(6,uvs[:,0],uvs[:,1])
         if bn_cache is not None:
             bn_cache.append(bn)
     else:
-        bn = bn_cache[0]
-    result = np.linalg.lstsq(bn.T @ bn, bn.T @ points, rcond=None)
-    ctrl = result[0]
-    residuals = result[1]
+        bn=bn_cache[0]
+    result=np.linalg.lstsq(bn.T@bn,bn.T@points,rcond=None)
+    ctrl=result[0] 
+    residuals=result[1]
 
     if residuals is None:
         logging.warning("Residuals are None")
     else:
-        err = np.linalg.norm(residuals)
-        if err > 1e-3:
+        err=np.linalg.norm(residuals)
+        if err>1e-3:
             logging.warning(f"Large error: {err}")
 
-    weight = np.ones_like(ctrl[:, 0:1])
-    ctrl = np.concatenate((ctrl, weight), axis=-1)
+    weight=np.ones_like(ctrl[:,0:1])
+    ctrl=np.concatenate((ctrl,weight),axis=-1)
     return ctrl
 
 
 def generate_uvw(num_points):
     points = []
     for _ in range(num_points):
+        # 生成均匀分布的随机数
         x = np.random.rand()
         y = np.random.rand()
+        # 计算 (u, v) 值
         if x + y > 1:
             u = x - (x + y - 1)
             v = y - (x + y - 1)
         else:
             u = x
             v = y
-
+        
+        # 计算 w
         w = 1 - u - v
-
+        
         points.append((u, v, w))
 
-    points = np.array(points)
-
+    points=np.array(points)
+    
     return points
+def getControlPointsFromApproximation(triangle:Triangle,face:Face,edge=None,edge_idx=0,uvs_random=generate_uvw(100)[:,:2]):
+    v1=triangle.v1
+    v2=triangle.v2
+    v3=triangle.v3
 
+    # uvs=np.array([[0,0],[0,1],[1,0],[0,1/3],[0,2/3],[1/3,2/3],[2/3,1/3],[2/3,0],[1/3,0],
+    #                 [1/9,1/9],[1/9,7/9],[7/9,1/9],
+    #                 [(1/3)*(7/9)+(2/3)*(1/9),1/9],[1-(1/3)*(7/9)-(2/3)*(1/9)-1/9,1/9],
+    #                 [1/9,(1/3)*(7/9)+(2/3)*(1/9)],[1/9,1-(1/3)*(7/9)-(2/3)*(1/9)-1/9],
+    #                 [(1/3)*(7/9)+(2/3)*(1/9),1-(1/3)*(7/9)-(2/3)*(1/9)-1/9],[1-(1/3)*(7/9)-(2/3)*(1/9)-1/9,(1/3)*(7/9)+(2/3)*(1/9)],
 
-def getControlPointsFromApproximation(
-    triangle: Triangle, face: Face, edge=None, edge_idx=0, uvs_random=generate_uvw(100)[:, :2]
-):
-    v1 = triangle.v1
-    v2 = triangle.v2
-    v3 = triangle.v3
+    #                 [2/9,2/9],[2/9,5/9],[5/9,2/9],
+    #                 [(1/3)*(5/9)+(2/3)*(2/9),2/9],[1-(1/3)*(5/9)-(2/3)*(2/9)-2/9,2/9],
+    #                 [2/9,(1/3)*(5/9)+(2/3)*(2/9)],[2/9,1-(1/3)*(5/9)-(2/3)*(2/9)-2/9],
+    #                 [(1/3)*(5/9)+(2/3)*(2/9),1-(1/3)*(5/9)-(2/3)*(2/9)-2/9],[1-(1/3)*(5/9)-(2/3)*(2/9)-2/9,(1/3)*(5/9)+(2/3)*(2/9)],
 
-    uvs_base = np.array(
-        [[0, 0], [0, 1], [1, 0], [0, 1 / 3], [0, 2 / 3], [1 / 3, 2 / 3], [2 / 3, 1 / 3], [2 / 3, 0], [1 / 3, 0]]
-    )
+    #                 [1/3,1/3]
+    #                 ])
+    uvs_base=np.array([[0,0],[0,1],[1,0],[0,1/3],[0,2/3],[1/3,2/3],[2/3,1/3],[2/3,0],[1/3,0]])
+    # uvs_random=generate_uvw(100)[:,:2]
+    uvs=np.concatenate([uvs_base,uvs_random],axis=0)
 
-    uvs = np.concatenate([uvs_base, uvs_random], axis=0)
-
-    params = [[v3[i] * u + v2[i] * v + v1[i] * (1 - u - v) for i in range(2)] for (u, v) in uvs]
-    points = [pointOnFace(face, p) for p in params]
+    params=[[v3[i]*u+v2[i]*v+v1[i]*(1-u-v) for i in range(2)] for (u,v) in uvs]
+    points=[pointOnFace(face,p) for p in params]
     if edge:
-        edge: BoundaryEdge
-        old_points = [params[edge_idx], params[(edge_idx + 1) % 3]]
-
-        if isClose(edge.start_point, old_points[0]):
-            params_ = [edge.params[0] * 2 / 3 + edge.params[1] * 1 / 3, edge.params[0] * 1 / 3 + edge.params[1] * 2 / 3]
+        edge:BoundaryEdge
+        old_points=[params[edge_idx],params[(edge_idx+1)%3]]
+        # edge3d:Edge=edge.edge3d
+        if isClose(edge.start_point,old_points[0]):
+            params_=[edge.params[0]*2/3+edge.params[1]*1/3,edge.params[0]*1/3+edge.params[1]*2/3]
 
         else:
-            params_ = [edge.params[0] * 1 / 3 + edge.params[1] * 2 / 3, edge.params[0] * 2 / 3 + edge.params[1] * 1 / 3]
+            params_=[edge.params[0]*1/3+edge.params[1]*2/3,edge.params[0]*2/3+edge.params[1]*1/3]
+            
+        params_=[geom_utils.gp_to_numpy(edge.crv.Value(p)) for p in params_]
+        replace_points=[pointOnFace(face,p) for p in params_]
 
-        params_ = [geom_utils.gp_to_numpy(edge.crv.Value(p)) for p in params_]
-        replace_points = [pointOnFace(face, p) for p in params_]
+        points[3+edge_idx*2:3+edge_idx*2+2]=replace_points
 
-        points[3 + edge_idx * 2 : 3 + edge_idx * 2 + 2] = replace_points
+    # ctrl_pts=np.empty(shape=(len(points),3),dtype=np.float32)
+    points=np.array(points)
 
-    points = np.array(points)
+    center,scale=getCenterAndScale(points)
 
-    center, scale = getCenterAndScale(points)
+    points=points-center
+    points=points*scale
 
-    points = points - center
-    points = points * scale
+    ctrl_pts=points
 
-    ctrl_pts = points
+    ctrl_pts=fit_bezier_surface2(points,uvs,ctrl_pts)
 
-    ctrl_pts = fit_bezier_surface2(points, uvs, ctrl_pts)
+    ctrl_pts[...,:3]/=scale
+    ctrl_pts[...,:3]+=center
 
-    ctrl_pts[..., :3] /= scale
-    ctrl_pts[..., :3] += center
-
+    # if np.any(np.isnan(ctrl_pts)):
+    #     logging.error(f"nan in control points")
+    #     raise ValueError("nan in control points")
+        
     return ctrl_pts
 
-
-def getControlPointsFromRect(patch, surface, loc):
-    tri_converter = Rectangular2TriangularBezier()
+def getControlPointsFromRect(patch,surface,loc):
+    tri_converter=Rectangular2TriangularBezier()
     nU_ctrl_pts, nV_ctrl_pts = 4, 4
-    channel_size = 4
-
-    max_degree = 3
+    channel_size=4
+    
+    max_degree=3
     patch.Increase(max_degree, max_degree)
+    # assert nU_ctrl_pts == patch.NbUPoles() and nV_ctrl_pts == patch.NbVPoles()
     poles = np.zeros([nU_ctrl_pts, nV_ctrl_pts, channel_size])
-
+    # print(patch.NbUPoles(),patch.NbVPoles())
     for u, v in np.ndindex((nU_ctrl_pts, nV_ctrl_pts)):
-        p = patch.Pole(u + 1, v + 1)
-        w = patch.Weight(u + 1, v + 1)
 
-        p = p.Transformed(loc.Transformation())
+        # print('trace',u,v)
+        p = patch.Pole(u+1, v+1)
+        w = patch.Weight(u+1, v+1)
+
+        p=p.Transformed(loc.Transformation())
         poles[u, v] = [p.X(), p.Y(), p.Z(), w]
+        # poles[u, v] = [p.X(), p.Y(), p.Z()]
 
-    if poles[..., -1].sum() < 1e-6:
-        poles[..., -1] = 1
+    if poles[...,-1].sum()<1e-6:
+        poles[...,-1]=1
 
-    deg, node1, node2 = tri_converter.convert(poles, rational=True)
+    deg,node1,node2=tri_converter.convert(poles,rational=True)
 
-    return node1, node2
+
+    # if np.any(np.isnan(node1))or np.any(np.isnan(node2)):
+    #     logging.error(f"nan in control points")
+    #     raise ValueError("nan in control points")
+
+    return node1,node2
+
+
+def normalOnFace(face, uv):
+    """
+    Compute the normal of the surface geometry at given parameter
+
+    Args:
+        uv (np.ndarray or tuple): Surface parameter
+
+    Returns:
+        np.ndarray: 3D unit normal vector
+    """
+    self=face
+    loc = TopLoc_Location()
+    surf = BRep_Tool.Surface(self.topods_shape(), loc)
+    res = GeomLProp_SLProps(surf, uv[0], uv[1], 1, 1e-9)
+    if not res.IsNormalDefined():
+        return (0, 0, 0)
+    gp_normal = res.Normal()
+    gp_normal.Transformed(loc.Transformation())
+    normal = geom_utils.gp_to_numpy(gp_normal)
+    if self.reversed():
+        normal = -normal
+    return normal
+
+def curvatureOnFace(face, uv):
+    """
+    Compute the gaussian curvature of the surface geometry at given parameter
+
+    Args:
+        uv (np.ndarray or tuple): Surface parameter
+
+    Returns:
+        float
+    """
+    self=face
+    loc = TopLoc_Location()
+    surf = BRep_Tool.Surface(self.topods_shape(), loc)
+    res = GeomLProp_SLProps(surf, uv[0], uv[1], 1, 1e-9)
+    if not res.IsCurvatureDefined():
+        return None
+    curvature = res.GaussianCurvature()
+    return curvature

--- a/process/utils/triangle.py
+++ b/process/utils/triangle.py
@@ -1,129 +1,201 @@
-from typing import List
+from scipy.special import binom
+import numpy as np
 
+from typing import Optional,List
+import math
 
+def isClose(pt1,pt2,tol=1e-6):
+    return np.linalg.norm(pt1-pt2)<=tol
 class Triangle:
-    def __init__(self, v1, v2, v3) -> None:
-        self.v1 = v1
-        self.v2 = v2
-        self.v3 = v3
-        self.control_points = None
-
+    def __init__(self,v1,v2,v3) -> None:
+        self.v1=v1
+        self.v2=v2
+        self.v3=v3
+        self.control_points=None
 
 class BoundaryEdge:
-    def __init__(self, start_point, end_point, uv, crv, edge3d) -> None:
-        self.start_point = start_point
-        self.end_point = end_point
+    def __init__(self,start_point,end_point,uv,crv,edge3d) -> None:
+        self.start_point=start_point
+        self.end_point=end_point
         self.params = uv
-        self.crv = crv
-        self.edge3d = edge3d
+        self.crv=crv
+        self.edge3d=edge3d
 
+class Rectangular2TriangularBezier:
+
+    def __init__(self) -> None:
+        pass
+
+    def convert_(self,control_pts,invert=False):
+        '''
+            control_pts: m x n array
+        '''
+        m,n,_=control_pts.shape
+        m-=1
+        n-=1
+        nodes=[]
+
+        degree=m+n
+        const1=1./binom(degree,n)
+
+        for s in range(degree,-1,-1):
+            for b in range(s+1):
+                a=s-b
+                v=[]
+                for j in range(a+1):
+                    const_aj=binom(a,j)
+
+                    item_sum=[]
+
+                    for k in range(max(0,b-m+j),min(b,n-a+j)+1):
+                        if invert:
+                            item=control_pts[m-j,n-k]*binom(b,k)*binom(m+n-a-b,m+k-j-b)
+                        else:
+                            item=control_pts[j,k]*binom(b,k)*binom(m+n-a-b,m+k-j-b)
+                        item_sum.append(item)
+
+                    item_sum=sum(item_sum)
+                    item_sum*=const_aj
+
+                    v.append(item_sum)
+                v=sum(v)
+                nodes.append(v)
+
+        nodes=np.stack(nodes)
+        nodes*=const1
+
+        return degree,nodes
+
+    def convert(self,control_pts,rational=False):
+        if not rational:
+            deg,nodes1=self.convert_(control_pts)
+            deg,nodes2=self.convert_(control_pts,invert=True)
+        else:
+            control_pts=np.array(control_pts)
+            control_pts[...,:-1]*=control_pts[...,[-1]]
+
+            # print(control_pts.shape)
+
+            deg,nodes1=self.convert_(control_pts)
+            deg,nodes2=self.convert_(control_pts,invert=True)
+            nodes1[...,:-1]/=nodes1[...,[-1]]
+            nodes2[...,:-1]/=nodes2[...,[-1]]
+
+            # print(nodes1.shape)
+            # exit(0)
+
+        return deg,nodes1,nodes2
 
 class PointInfo:
     def __init__(self) -> None:
-        self.coord = None
-        self.boundary_status = None  # 0: inside, 1: outside, 2: on
+        self.coord=None
+        self.boundary_status = None # 0: inside, 1: outside, 2: on
         self.is_on_rectangle = False
-        self.param_on_curve = None
-        self.belong_edges = []
-        self.belong_rectangle_indices = []  # [(i,j),...]
+        self.param_on_curve=None
+        self.belong_edges=[]
+        self.belong_rectangle_indices=[] # [(i,j),...]
+
+class RectInfo:
+    def __init__(self) -> None:
+        self.end_points=None
+        self.isBroken=False
+        self.upper_triangle=None
+        self.lower_triangle=None
 
 
 class PointsManager:
-    def __init__(self, tolerance=1e-4) -> None:
+    def __init__(self,tolerance=1e-4) -> None:
         self.tolerance = tolerance
         self.points_dict = dict()
         self.scale = 1 / tolerance  # Scaling factor for quantization
-        self.point_data = []
-
-    def getPointInfomation(self, point):
+        self.point_data=[]
+    
+    def getPointInfomation(self,point):
         """
-        args: point: (x,y)
-        return: PointInfo or None if not found
+            args: point: (x,y)
+            return: PointInfo or None if not found
         """
-        h = self.getHash(point)
-        idx = self.points_dict.get(h)
+        h=self.getHash(point)
+        idx=self.points_dict.get(h)
         if idx is None:
             return None
         return self.point_data[idx]
 
-    def addPointInfo(self, point_info: PointInfo):
+    def addPointInfo(self,point_info:PointInfo):
         """
-        args: point_info: PointInfo
+            args: point_info: PointInfo
         """
-        h = self.getHash(point_info.coord)
-        idx = self.points_dict.get(h)
+        h=self.getHash(point_info.coord)
+        idx=self.points_dict.get(h)
         if idx is None:
-            idx = len(self.point_data)
-            self.points_dict[h] = idx
+            idx=len(self.point_data)
+            self.points_dict[h]=idx
             self.point_data.append(point_info)
 
         return idx
-
-    def addPoint(self, point):
+    def addPoint(self,point):
         """
-        args: point: (x,y)
+            args: point: (x,y)
         """
-        h = self.getHash(point)
-        idx = self.points_dict.get(h)
+        h=self.getHash(point)
+        idx=self.points_dict.get(h)
         if idx is None:
-            idx = len(self.point_data)
-            self.points_dict[h] = idx
-            point_info = PointInfo()
-            point_info.coord = point
+            idx=len(self.point_data)
+            self.points_dict[h]=idx
+            point_info=PointInfo()
+            point_info.coord=point
             self.point_data.append(point_info)
 
         return idx
-
-    def getPointId(self, point):
+    def getPointId(self,point):
         """
-        args: point: (x,y)
+            args: point: (x,y)
         """
-        h = self.getHash(point)
+        h=self.getHash(point)
         return self.points_dict.get(h)
 
-    def points(self) -> List[PointInfo]:
+    def points(self)->List[PointInfo]:
         """
-        return Iterable of PointInfos
+            return Iterable of PointInfos
         """
         return self.point_data
-
-    def getHash(self, point):
-        return (int(round(point[0] * self.scale)), int(round(point[1] * self.scale)))
+    def getHash(self,point):
+        return (int(round(point[0] * self.scale)),int(round(point[1] * self.scale)))
 
 
 class TraingleEdgeManager:
     def __init__(self) -> None:
-        self.data = dict()
+        self.data=dict()
 
-    def get_adjacent_triangles(self, edge):
+    def get_adjacent_triangles(self,edge):
         """
-        args: edge: (idx1,idx2)
-        return: adjacent triangles: [Trangle1,Trangle2]
+            args: edge: (idx1,idx2)
+            return: adjacent triangles: [Trangle1,Trangle2]
         """
 
-        if edge[1] > edge[0]:
-            edge = (edge[1], edge[0])
+        if edge[1]>edge[0]:
+            edge=(edge[1],edge[0])
         return self.data[edge]
-
-    def add_adjacent_triangles(self, edge, triangle):
-        """ """
-        if edge[1] > edge[0]:
-            edge = (edge[1], edge[0])
-
-        lst = self.data.get(edge, [])
+    def add_adjacent_triangles(self,edge,triangle):
+        """
+        """
+        if edge[1]>edge[0]:
+            edge=(edge[1],edge[0])
+        
+        lst=self.data.get(edge,[])
         lst.append(triangle)
-        if len(lst) == 1:
-            self.data[edge] = lst
+        if len(lst)==1:
+            self.data[edge]=lst
 
     def connections(self):
         """
-        return: Iterable of (edge,triangle_id)
+            return: Iterable of (edge,triangle_id)
         """
-        result = []
+        result=[]
         for values in self.data.values():
-            if len(values) < 2:
+            if len(values)<2:
                 continue
-            u, v = values
-            result.append((u, v))
-            result.append((v, u))
+            u,v = values
+            result.append((u,v))
+            result.append((v,u))
         return result


### PR DESCRIPTION
add an option of convert B-spline surface into rectangular bezier patches instead of triangular bezier patches (See process/gen_temcad_rectangles.py). 

The number of control points of each patch is 16 (4*4). To train the model with rectangular patches, the argument `num_control_pts` in the training scripts should be set as m*n, (16 in the case of 4*4).